### PR TITLE
Add handling of 8 bytes long

### DIFF
--- a/torchfile.py
+++ b/torchfile.py
@@ -78,19 +78,15 @@ def add_tensor_reader(typename, dtype):
         # source:
         # https://github.com/torch/torch7/blob/master/generic/Tensor.c#L1243
         ndim = reader.read_int()
-        print 'reading tensor', typename, 'ndim=', ndim 
+ 
         # read size:
         size = reader.read_long_array(ndim)
-        print 'reading tensor', typename, 'size=', size 
         # read stride:
         stride = reader.read_long_array(ndim)
-        print 'reading tensor', typename, 'stride=', stride 
         # storage offset:
         storage_offset = reader.read_long() - 1
-        print 'reading tensor', typename, 'storage_offset=', storage_offset
         # read storage:
         storage = reader.read_obj()
-        print 'reading tensor', typename, 'storage=', storage
         
         if storage is None or ndim == 0 or len(size) == 0 or len(stride) == 0:
             # empty torch tensor
@@ -350,24 +346,20 @@ class T7Reader:
                 if className not in torch_readers:
                     if not self.force_deserialize_classes:
                         raise T7ReaderException(
-                            'unsupported torch class: <%s>' % className)
-                    print 'reading TorchObject', className, 'version=', version, 'at index', index      
+                            'unsupported torch class: <%s>' % className)   
                     obj = TorchObject(className, self.read_obj())
                 else:
-                    print 'reading torch_readers', className, 'version=', version, 'at index', index
                     obj = torch_readers[className](self, version)
                 self.objects[index] = obj
                 return obj
             else:  # it is a table: returns a custom dict or a list
                 size = self.read_int()
-                print 'reading table', 'size=', size, 'at index', index
                 obj = hashable_uniq_dict()  # custom hashable dict, can be a key
                 key_sum = 0                # for checking if keys are consecutive
                 keys_natural = True        # and also natural numbers 1..n.
                 # If so, returns a list with indices converted to 0-indices.
                 for i in range(size):
                     k = self.read_obj()
-                    print 'reading table key', k
                     v = self.read_obj()
                     obj[k] = v
 

--- a/torchfile.py
+++ b/torchfile.py
@@ -245,7 +245,7 @@ class T7Reader:
                  use_list_heuristic=True,
                  use_int_heuristic=True,
                  force_deserialize_classes=True,
-                 use_8bytes_long=True):
+                 force_8bytes_long=False):
         """
         Params:
         * `fileobj` file object to read from, must be actual file object
@@ -263,7 +263,7 @@ class T7Reader:
         self.use_list_heuristic = use_list_heuristic
         self.use_int_heuristic = use_int_heuristic
         self.force_deserialize_classes = force_deserialize_classes
-        self.use_8bytes_long = use_8bytes_long
+        self.force_8bytes_long = force_8bytes_long
 
     def _read(self, fmt):
         sz = struct.calcsize(fmt)
@@ -276,13 +276,13 @@ class T7Reader:
         return self._read('i')[0]
 
     def read_long(self):
-        if self.use_8bytes_long:
+        if self.force_8bytes_long:
             return self._read('q')[0]
         else:
             return self._read('l')[0]
 
     def read_long_array(self, n):
-        if self.use_8bytes_long:
+        if self.force_8bytes_long:
             lst = []
             for i in xrange(n):
                 lst.append(self.read_long())

--- a/torchfile.py
+++ b/torchfile.py
@@ -78,7 +78,7 @@ def add_tensor_reader(typename, dtype):
         # source:
         # https://github.com/torch/torch7/blob/master/generic/Tensor.c#L1243
         ndim = reader.read_int()
- 
+
         # read size:
         size = reader.read_long_array(ndim)
         # read stride:
@@ -87,7 +87,7 @@ def add_tensor_reader(typename, dtype):
         storage_offset = reader.read_long() - 1
         # read storage:
         storage = reader.read_obj()
-        
+
         if storage is None or ndim == 0 or len(size) == 0 or len(stride) == 0:
             # empty torch tensor
             return np.empty((0), dtype=dtype)
@@ -346,7 +346,7 @@ class T7Reader:
                 if className not in torch_readers:
                     if not self.force_deserialize_classes:
                         raise T7ReaderException(
-                            'unsupported torch class: <%s>' % className)   
+                            'unsupported torch class: <%s>' % className)
                     obj = TorchObject(className, self.read_obj())
                 else:
                     obj = torch_readers[className](self, version)


### PR DESCRIPTION
The previous version uses 4 bytes long to read tensor, this won't work with files under https://github.com/facebook/fb.resnet.torch/tree/master/pretrained, since they're using 8 bytes long.
