### PR TITLE
Casting version to float for Lua 5.3 compat.

### DIFF
--- a/torchfile.py
+++ b/torchfile.py
@@ -361,7 +361,7 @@ class T7Reader:
             elif typeidx == TYPE_TORCH:
                 version = self.read_string()
                 if version.startswith(b'V '):
-                    versionNumber = int(version.partition(b' ')[2])
+                    versionNumber = int(float(version.partition(b' ')[2]))
                     className = self.read_string()
                 else:
                     className = version


### PR DESCRIPTION
Lua 5.3 seems to write versions as floats (`1.0` instead of `1`); this patch pre-casts the version string as a float, then an int. 

Fixed [this issue](https://github.com/bshillingford/python-torchfile/issues/5).